### PR TITLE
Show score in Strongest/Weakest Principle stat cards

### DIFF
--- a/src/components/ModelsTable.vue
+++ b/src/components/ModelsTable.vue
@@ -17,7 +17,6 @@
       <table class="models-table">
         <thead>
           <tr>
-            <th class="col-rank" @click="sortBy('rank')"># <span v-if="sortKey === 'rank'" class="sort-arrow">{{ sortDir === 'asc' ? '\u25B2' : '\u25BC' }}</span></th>
             <th class="col-model" @click="sortBy('displayName')">Model <span v-if="sortKey === 'displayName'" class="sort-arrow">{{ sortDir === 'asc' ? '\u25B2' : '\u25BC' }}</span></th>
             <th class="col-provider" @click="sortBy('provider')">Provider <span v-if="sortKey === 'provider'" class="sort-arrow">{{ sortDir === 'asc' ? '\u25B2' : '\u25BC' }}</span></th>
             <th class="col-score" @click="sortBy('humaneScore')">HumaneScore <span v-if="sortKey === 'humaneScore'" class="sort-arrow">{{ sortDir === 'asc' ? '\u25B2' : '\u25BC' }}</span></th>
@@ -33,7 +32,6 @@
         </thead>
         <tbody>
           <tr v-for="model in sortedModels" :key="model.id">
-            <td class="col-rank">{{ model.rank }}</td>
             <td class="col-model">
               <router-link :to="{ name: 'model-detail', params: { modelId: model.id } }" class="model-link">
                 {{ model.displayName }}
@@ -83,8 +81,8 @@ export default defineComponent({
 
   data() {
     return {
-      sortKey: 'rank' as string,
-      sortDir: 'asc' as 'asc' | 'desc',
+      sortKey: 'humaneScore' as string,
+      sortDir: 'desc' as 'asc' | 'desc',
       selectedDataset: 'baseline' as keyof RankedModelEntry['scores'],
       datasetOptions: DATASET_OPTIONS,
     };
@@ -117,10 +115,7 @@ export default defineComponent({
         let aVal: string | number;
         let bVal: string | number;
 
-        if (key === 'rank') {
-          aVal = a.rank;
-          bVal = b.rank;
-        } else if (key === 'humaneScore') {
+        if (key === 'humaneScore') {
           aVal = a.scores[this.selectedDataset]?.['HumaneScore'] ?? -999;
           bVal = b.scores[this.selectedDataset]?.['HumaneScore'] ?? -999;
         } else if (key === 'displayName') {
@@ -148,7 +143,7 @@ export default defineComponent({
         this.sortDir = this.sortDir === 'asc' ? 'desc' : 'asc';
       } else {
         this.sortKey = key;
-        this.sortDir = key === 'rank' || key === 'displayName' || key === 'provider' ? 'asc' : 'desc';
+        this.sortDir = key === 'displayName' || key === 'provider' ? 'asc' : 'desc';
       }
     },
 
@@ -272,12 +267,6 @@ export default defineComponent({
 .sort-arrow {
   font-size: 0.65rem;
   margin-left: 0.2rem;
-}
-
-.col-rank {
-  width: 3rem;
-  text-align: center;
-  font-variant-numeric: tabular-nums;
 }
 
 .col-score {

--- a/src/utils/modelData.ts
+++ b/src/utils/modelData.ts
@@ -123,6 +123,11 @@ export function getStrongestPrinciple(model: ModelDetailEntry): PrincipleScore |
   return [...model.principles].sort((a, b) => b.score - a.score)[0];
 }
 
+export function getWeakestPrinciple(model: ModelDetailEntry): PrincipleScore | null {
+  if (!model.principles.length) return null;
+  return [...model.principles].sort((a, b) => a.score - b.score)[0];
+}
+
 let cachedData: ModelScoresJson | null = null;
 
 async function loadData(): Promise<ModelScoresJson> {

--- a/src/views/ModelDetailPage.vue
+++ b/src/views/ModelDetailPage.vue
@@ -38,12 +38,14 @@
               <div class="stat-card">
                 <div class="stat-card-label">Strongest Principle</div>
                 <div class="stat-card-value stat-card-text">{{ strongestPrincipleName }}</div>
+                <div class="stat-card-sub-score">{{ strongestPrincipleScore }}</div>
               </div>
             </v-col>
             <v-col cols="12" sm="4">
               <div class="stat-card">
                 <div class="stat-card-label">Weakest Principle</div>
                 <div class="stat-card-value stat-card-text">{{ weakestPrincipleName }}</div>
+                <div class="stat-card-sub-score">{{ weakestPrincipleScore }}</div>
               </div>
             </v-col>
           </v-row>
@@ -174,6 +176,18 @@ export default defineComponent({
       const weakest = getWeakestPrinciple(this.model);
       return weakest ? weakest.name : 'N/A';
     },
+
+    strongestPrincipleScore(): string {
+      if (!this.model) return '';
+      const strongest = getStrongestPrinciple(this.model);
+      return strongest ? strongest.score.toFixed(2) : '';
+    },
+
+    weakestPrincipleScore(): string {
+      if (!this.model) return '';
+      const weakest = getWeakestPrinciple(this.model);
+      return weakest ? weakest.score.toFixed(2) : '';
+    },
   },
 
   watch: {
@@ -244,6 +258,14 @@ export default defineComponent({
   font-size: 0.9rem;
   font-weight: 400;
   color: #999;
+}
+
+.stat-card-sub-score {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #8b7dd8;
+  font-variant-numeric: tabular-nums;
+  margin-top: 0.35rem;
 }
 
 .section-card {

--- a/src/views/ModelDetailPage.vue
+++ b/src/views/ModelDetailPage.vue
@@ -36,14 +36,14 @@
             </v-col>
             <v-col cols="12" sm="4">
               <div class="stat-card">
-                <div class="stat-card-label">Overall Rank</div>
-                <div class="stat-card-value">#{{ modelRank }} <span class="stat-card-context">of {{ totalModels }}</span></div>
+                <div class="stat-card-label">Strongest Principle</div>
+                <div class="stat-card-value stat-card-text">{{ strongestPrincipleName }}</div>
               </div>
             </v-col>
             <v-col cols="12" sm="4">
               <div class="stat-card">
-                <div class="stat-card-label">Strongest Principle</div>
-                <div class="stat-card-value stat-card-text">{{ strongestPrincipleName }}</div>
+                <div class="stat-card-label">Weakest Principle</div>
+                <div class="stat-card-value stat-card-text">{{ weakestPrincipleName }}</div>
               </div>
             </v-col>
           </v-row>
@@ -92,10 +92,9 @@
 import { defineComponent } from 'vue';
 import {
   fetchModelById,
-  fetchRankedModels,
   getStrongestPrinciple,
+  getWeakestPrinciple,
   type ModelDetailEntry,
-  type RankedModelEntry,
 } from '@/utils/modelData';
 import NutritionLabel from '@/components/NutritionLabel.vue';
 import ModelNotFound from '@/components/ModelNotFound.vue';
@@ -123,8 +122,6 @@ export default defineComponent({
     return {
       loading: true,
       model: null as ModelDetailEntry | null,
-      modelRank: 0,
-      totalModels: 0,
     };
   },
 
@@ -171,6 +168,12 @@ export default defineComponent({
       const strongest = getStrongestPrinciple(this.model);
       return strongest ? strongest.name : 'N/A';
     },
+
+    weakestPrincipleName(): string {
+      if (!this.model) return 'N/A';
+      const weakest = getWeakestPrinciple(this.model);
+      return weakest ? weakest.name : 'N/A';
+    },
   },
 
   watch: {
@@ -178,14 +181,7 @@ export default defineComponent({
       immediate: true,
       async handler(id: string) {
         this.loading = true;
-        const [model, ranked] = await Promise.all([
-          fetchModelById(id),
-          fetchRankedModels(),
-        ]);
-        this.model = model;
-        this.totalModels = ranked.length;
-        const found = ranked.find((m: RankedModelEntry) => m.id === id);
-        this.modelRank = found ? found.rank : 0;
+        this.model = await fetchModelById(id);
         this.loading = false;
       },
     },
@@ -218,6 +214,10 @@ export default defineComponent({
   border-radius: 8px;
   padding: 1.25rem;
   text-align: center;
+  min-height: 120px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .stat-card-label {


### PR DESCRIPTION
## Summary

**Remove rankings, add Weakest Principle stat card**
- Remove `#` rank column from `ModelsTable`; default sort is now HumaneScore descending
- Add `getWeakestPrinciple()` utility (parallel to `getStrongestPrinciple`)
- Replace Overall Rank card on model detail pages with Weakest Principle
- Stat card order: HumaneScore | Strongest Principle | Weakest Principle
- Fix stat card sizing with min-height + flex centering for consistent height

**Show score in Strongest/Weakest Principle stat cards**
- Add `strongestPrincipleScore` and `weakestPrincipleScore` computed properties
- Render the numeric score (e.g. `0.84`) below the principle name in each stat card
- Style the score in muted purple (`#8b7dd8`) at 0.9rem semi-bold — visually secondary to the name but legible

## Test plan

- [ ] Models table no longer shows a rank column; rows sort by HumaneScore by default
- [ ] Model detail pages show three stat cards: HumaneScore, Strongest Principle, Weakest Principle
- [ ] Strongest and Weakest Principle cards each show the principle name with its numeric score below
- [ ] Score is visually subordinate to the name; HumaneScore card is unaffected
- [ ] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)