### PR TITLE
feat: Rename News → News & Citations, add arxiv and MIT Media Lab references

### DIFF
--- a/src/components/News.vue
+++ b/src/components/News.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card class="p-8 md:p-6 sm:p-4 mb-12 md:mb-8 shadow-md rounded-lg">
     <div v-for="(item, index) in news" :key="index" :class="{ 'mb-8': index < news.length - 1 }">
-      <h3 class="text-2xl md:text-xl sm:text-lg font-semibold mb-3 flex items-center gap-2 flex-wrap" :class="{ 'mt-0': index === 0 }">
+      <h3 class="text-2xl md:text-xl sm:text-lg font-semibold mb-3 flex items-center gap-2" :class="{ 'mt-0': index === 0 }">
         <v-icon size="28">{{ item.icon || (item.type === 'citation' ? 'mdi-format-quote-close' : 'mdi-newspaper') }}</v-icon>
         {{ item.title }}
       </h3>

--- a/src/components/News.vue
+++ b/src/components/News.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card class="p-8 md:p-6 sm:p-4 mb-12 md:mb-8 shadow-md rounded-lg">
     <div v-for="(item, index) in news" :key="index" :class="{ 'mb-8': index < news.length - 1 }">
-      <h3 class="text-2xl md:text-xl sm:text-lg font-semibold mb-3 flex items-center gap-2" :class="{ 'mt-0': index === 0 }">
+      <h3 class="text-2xl md:text-xl sm:text-lg font-semibold mb-3 flex items-start gap-2" :class="{ 'mt-0': index === 0 }">
         <v-icon size="28">{{ item.icon || (item.type === 'citation' ? 'mdi-format-quote-close' : 'mdi-newspaper') }}</v-icon>
         {{ item.title }}
       </h3>

--- a/src/components/News.vue
+++ b/src/components/News.vue
@@ -2,7 +2,7 @@
   <v-card class="p-8 md:p-6 sm:p-4 mb-12 md:mb-8 shadow-md rounded-lg">
     <div v-for="(item, index) in news" :key="index" :class="{ 'mb-8': index < news.length - 1 }">
       <h3 class="text-2xl md:text-xl sm:text-lg font-semibold mb-3 flex items-center gap-2 flex-wrap" :class="{ 'mt-0': index === 0 }">
-        <v-icon size="28">mdi-newspaper</v-icon>
+        <v-icon size="28">{{ item.type === 'citation' ? 'mdi-format-quote-close' : 'mdi-newspaper' }}</v-icon>
         {{ item.title }}
       </h3>
       <p class="text-base text-gray-700 mb-4">
@@ -15,7 +15,7 @@
         :href="item.link"
         target="_blank"
       >
-        Read article
+        {{ item.type === 'citation' ? 'Read paper' : 'Read article' }}
       </v-btn>
     </div>
   </v-card>
@@ -28,6 +28,7 @@ interface NewsItem {
   title: string;
   description: string;
   link: string;
+  type?: string;
 }
 
 export default defineComponent({
@@ -41,4 +42,3 @@ export default defineComponent({
   }
 });
 </script>
-

--- a/src/components/News.vue
+++ b/src/components/News.vue
@@ -2,7 +2,7 @@
   <v-card class="p-8 md:p-6 sm:p-4 mb-12 md:mb-8 shadow-md rounded-lg">
     <div v-for="(item, index) in news" :key="index" :class="{ 'mb-8': index < news.length - 1 }">
       <h3 class="text-2xl md:text-xl sm:text-lg font-semibold mb-3 flex items-center gap-2 flex-wrap" :class="{ 'mt-0': index === 0 }">
-        <v-icon size="28">{{ item.type === 'citation' ? 'mdi-format-quote-close' : 'mdi-newspaper' }}</v-icon>
+        <v-icon size="28">{{ item.icon || (item.type === 'citation' ? 'mdi-format-quote-close' : 'mdi-newspaper') }}</v-icon>
         {{ item.title }}
       </h3>
       <p class="text-base text-gray-700 mb-4">
@@ -15,7 +15,7 @@
         :href="item.link"
         target="_blank"
       >
-        {{ item.type === 'citation' ? 'Read paper' : 'Read article' }}
+        {{ item.linkLabel || (item.type === 'citation' ? 'Read paper' : 'Read article') }}
       </v-btn>
     </div>
   </v-card>
@@ -29,6 +29,8 @@ interface NewsItem {
   description: string;
   link: string;
   type?: string;
+  icon?: string;
+  linkLabel?: string;
 }
 
 export default defineComponent({

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -59,14 +59,14 @@ The [Building Humane Technology](https://www.buildinghumanetech.com/) team: [Eri
     "type": "citation"
   },
   {
-    "title": "MIT Media Lab's Human-AI Impact Bench Features HumaneBench",
+    "title": "MIT Media Lab Human-AI Impact Bench Features HumaneBench",
     "description": "MIT Media Lab has launched an open benchmark evaluating AI systems across physical, psychological, and societal dimensions of well-being, with HumaneBench recognized as a key contributing framework. Contact us for access to the benchmark.",
     "link": "https://impactbench.media.mit.edu/",
     "type": "citation"
   },
   {
     "title": "Panel: Benchmarking AI Impact — AHA Symposium at MIT Media Lab",
-    "description": "Erika Anderson joined Beth Goldberg (Google Jigsaw), James Donovan (OpenAI), and Yaoli Mao (Autodesk) to discuss benchmarking AI's impact on human well-being. Watch the full panel from the AHA Symposium 2026: Raised by AI?",
+    "description": "Erika Anderson joined Beth Goldberg (Google Jigsaw), James Donovan (OpenAI), and Yaoli Mao (Autodesk) to discuss benchmarking AI impact on human well-being. Watch the full panel from the AHA Symposium 2026: Raised by AI?",
     "link": "https://youtu.be/LgOE-uRs2IM?si=q3JSPv3QGzkmSjD2",
     "type": "citation",
     "icon": "mdi-video-outline",

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -49,13 +49,26 @@ Even without adversarial prompts, we found concerning baseline patterns. Nearly 
 
 The [Building Humane Technology](https://www.buildinghumanetech.com/) team: [Erika Anderson](https://www.linkedin.com/in/erikamanderson/), [Sarah Ladyman](https://www.linkedin.com/in/sarahladyman/), [Juan Ocampo](https://www.linkedin.com/in/juan-ocampo-ai-consulting/), [Andalib Samandari](https://www.linkedin.com/in/andalibsamandari/), [Jack Senechal](https://www.linkedin.com/in/jacksenechal/), and our dedicated community of collaborators who contributed to this project.
 
-## News
+## News & Citations
 
 <div data-component="News" data-news='[
   {
+    "title": "HumaneBench Cited in \"Positive Alignment\" Paper",
+    "description": "A 16-author paper from researchers at leading AI institutions argues the field must move beyond harm avoidance toward AI that actively promotes human flourishing — citing HumaneBench as part of the measurement infrastructure this paradigm requires.",
+    "link": "https://arxiv.org/abs/2605.10310",
+    "type": "citation"
+  },
+  {
+    "title": "MIT Media Lab's Human-AI Impact Bench Features HumaneBench",
+    "description": "MIT Media Lab has launched an open benchmark evaluating AI systems across physical, psychological, and societal dimensions of well-being, with HumaneBench recognized as a key contributing framework. Contact us for access to the benchmark.",
+    "link": "https://impactbench.media.mit.edu/",
+    "type": "citation"
+  },
+  {
     "title": "A new AI benchmark tests whether chatbots protect human wellbeing",
     "description": "TechCrunch covers HumaneBench, a benchmark measuring whether AI models support human flourishing, especially when pressured to do otherwise.",
-    "link": "https://techcrunch.com/2025/11/24/a-new-ai-benchmark-tests-whether-chatbots-protect-human-wellbeing/"
+    "link": "https://techcrunch.com/2025/11/24/a-new-ai-benchmark-tests-whether-chatbots-protect-human-wellbeing/",
+    "type": "news"
   }
 ]'></div>
 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -65,6 +65,14 @@ The [Building Humane Technology](https://www.buildinghumanetech.com/) team: [Eri
     "type": "citation"
   },
   {
+    "title": "Panel: Benchmarking AI Impact — AHA Symposium at MIT Media Lab",
+    "description": "Erika Anderson joined Beth Goldberg (Google Jigsaw), James Donovan (OpenAI), and Yaoli Mao (Autodesk) to discuss benchmarking AI's impact on human well-being. Watch the full panel from the AHA Symposium 2026: Raised by AI?",
+    "link": "https://youtu.be/LgOE-uRs2IM?si=q3JSPv3QGzkmSjD2",
+    "type": "citation",
+    "icon": "mdi-video-outline",
+    "linkLabel": "Watch panel"
+  },
+  {
     "title": "A new AI benchmark tests whether chatbots protect human wellbeing",
     "description": "TechCrunch covers HumaneBench, a benchmark measuring whether AI models support human flourishing, especially when pressured to do otherwise.",
     "link": "https://techcrunch.com/2025/11/24/a-new-ai-benchmark-tests-whether-chatbots-protect-human-wellbeing/",


### PR DESCRIPTION
## Changes

### 1. Renamed section: News → News & Citations
The section heading in `index.md` is now **News & Citations** to reflect both types of content.

### 2. Added arxiv citation
**"Positive Alignment: Artificial Intelligence for Human Flourishing"** (arxiv 2605.10310) — a 16-author paper from frontier AI labs that cites HumaneBench as part of the measurement infrastructure for the Positive Alignment paradigm.

### 3. Added MIT Media Lab Human-AI Impact Bench
MIT Media Lab has launched an open benchmark evaluating AI across physical, psychological, and societal dimensions of well-being, featuring HumaneBench as a key contributing framework. Currently password-protected; people can contact us for access.

### 4. Updated News component
Added support for a `type` field on news items (`citation` vs `news`):
- **Citation** items show a quote icon (mdi-format-quote-close) and "Read paper" button
- **News** items show a newspaper icon (mdi-newspaper) and "Read article" button
- Existing TechCrunch item defaults to `news` type

### Files changed
- `src/pages/index.md` — heading, new entries, type fields
- `src/components/News.vue` — type-aware icon and button label

Build passes ✅