### PR TITLE
Hide Events section when empty

### DIFF
--- a/src/components/Events.vue
+++ b/src/components/Events.vue
@@ -1,24 +1,24 @@
 <template>
   <section v-if="events.length > 0">
-    <h2 class="events-heading">Events</h2>
+    <h2>Events</h2>
     <v-card class="p-8 md:p-6 sm:p-4 mb-12 md:mb-8 shadow-md rounded-lg">
       <div v-for="(event, index) in events" :key="index" :class="{ 'mb-8': index < events.length - 1 }">
-      <h3 class="text-2xl md:text-xl sm:text-lg font-semibold mb-3 flex items-center gap-2 flex-wrap" :class="{ 'mt-0': index === 0 }">
-        <v-icon size="28">mdi-calendar-star</v-icon>
-        {{ event.title }}
-      </h3>
-      <p class="text-base text-gray-700 mb-4">
-        {{ event.description }}
-      </p>
-      <v-btn
-        color="black"
-        class="text-white text-none"
-        rounded="lg"
-        :href="event.link"
-        target="_blank"
-      >
-        Register here
-      </v-btn>
+        <h3 class="text-2xl md:text-xl sm:text-lg font-semibold mb-3 flex items-center gap-2 flex-wrap" :class="{ 'mt-0': index === 0 }">
+          <v-icon size="28">mdi-calendar-star</v-icon>
+          {{ event.title }}
+        </h3>
+        <p class="text-base text-gray-700 mb-4">
+          {{ event.description }}
+        </p>
+        <v-btn
+          color="black"
+          class="text-white text-none"
+          rounded="lg"
+          :href="event.link"
+          target="_blank"
+        >
+          Register here
+        </v-btn>
       </div>
     </v-card>
   </section>
@@ -44,28 +44,3 @@ export default defineComponent({
   }
 });
 </script>
-
-<style scoped>
-/* Match the markdown h2 styling from MarkdownPage.vue so the in-component
-   heading is visually identical to other section headings on the page. */
-.events-heading {
-  font-size: 2rem;
-  font-weight: bold;
-  margin-bottom: 1.5rem;
-  margin-top: 3rem;
-}
-
-@media (max-width: 768px) {
-  .events-heading {
-    font-size: 1.5rem;
-    margin-top: 2rem;
-  }
-}
-
-@media (max-width: 480px) {
-  .events-heading {
-    font-size: 1.35rem;
-    margin-top: 1.5rem;
-  }
-}
-</style>

--- a/src/components/Events.vue
+++ b/src/components/Events.vue
@@ -1,10 +1,8 @@
 <template>
-  <v-card class="p-8 md:p-6 sm:p-4 mb-12 md:mb-8 shadow-md rounded-lg">
-    <div v-if="events.length === 0" class="text-center py-4">
-      <v-icon size="40" color="grey-darken-1" class="mb-2">mdi-calendar-blank</v-icon>
-      <p class="text-lg text-gray-500">No events currently scheduled</p>
-    </div>
-    <div v-for="(event, index) in events" :key="index" :class="{ 'mb-8': index < events.length - 1 }">
+  <section v-if="events.length > 0">
+    <h2 class="events-heading">Events</h2>
+    <v-card class="p-8 md:p-6 sm:p-4 mb-12 md:mb-8 shadow-md rounded-lg">
+      <div v-for="(event, index) in events" :key="index" :class="{ 'mb-8': index < events.length - 1 }">
       <h3 class="text-2xl md:text-xl sm:text-lg font-semibold mb-3 flex items-center gap-2 flex-wrap" :class="{ 'mt-0': index === 0 }">
         <v-icon size="28">mdi-calendar-star</v-icon>
         {{ event.title }}
@@ -21,8 +19,9 @@
       >
         Register here
       </v-btn>
-    </div>
-  </v-card>
+      </div>
+    </v-card>
+  </section>
 </template>
 
 <script lang="ts">
@@ -45,3 +44,28 @@ export default defineComponent({
   }
 });
 </script>
+
+<style scoped>
+/* Match the markdown h2 styling from MarkdownPage.vue so the in-component
+   heading is visually identical to other section headings on the page. */
+.events-heading {
+  font-size: 2rem;
+  font-weight: bold;
+  margin-bottom: 1.5rem;
+  margin-top: 3rem;
+}
+
+@media (max-width: 768px) {
+  .events-heading {
+    font-size: 1.5rem;
+    margin-top: 2rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .events-heading {
+    font-size: 1.35rem;
+    margin-top: 1.5rem;
+  }
+}
+</style>

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -79,9 +79,9 @@ The [Building Humane Technology](https://www.buildinghumanetech.com/) team: [Eri
   }
 ]'></div>
 
-## Events
-
-<!-- Example:
+<!-- The "Events" heading is rendered by the Events component itself and the
+     whole section is hidden when data-events is empty. To show events, add
+     entries to the data-events array below. Example:
 <div data-component="Events" data-events='[
   {
     "title": "May 12, 2026 - Workshop: Tune Up Your AI",


### PR DESCRIPTION
## Summary
- The Events section on the home page now disappears entirely when there are no events scheduled, and repopulates automatically when events are added to the `data-events` array.
- Previously an empty events array showed a "No events currently scheduled" placeholder card, and the `## Events` markdown heading was always visible even with no content.

## Changes
- `src/components/Events.vue`: The component now renders its own `Events` heading (styled to match the markdown `h2`, including responsive breakpoints) and wraps the whole section in `v-if="events.length > 0"`, so heading + card are hidden together when empty. Removed the empty-state placeholder.
- `src/pages/index.md`: Removed the static `## Events` heading (now owned by the component) and updated the comment explaining how to add events.

## Testing
- `npm run lint` — no lint errors
- `npm run build` — build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)